### PR TITLE
URL params checking and documenting.

### DIFF
--- a/lib/fdoc/endpoint_scaffold.rb
+++ b/lib/fdoc/endpoint_scaffold.rb
@@ -17,11 +17,15 @@ class Fdoc::EndpointScaffold < Fdoc::Endpoint
 
   def persist!
     dirname = File.dirname(@endpoint_path)
-    Dir.mkdir(dirname) unless File.directory?(dirname)
+    FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
 
     File.open(@endpoint_path, "w") do |file|
       YAML.dump(@schema, file)
     end
+  end
+
+  def consume_path(params, successful = true)
+    # no-op
   end
 
   def consume_request(params, successful = true)

--- a/lib/fdoc/presenters/endpoint_presenter.rb
+++ b/lib/fdoc/presenters/endpoint_presenter.rb
@@ -16,7 +16,7 @@ class Fdoc::EndpointPresenter < Fdoc::HtmlPresenter
     <span class="endpoint-name #{@endpoint.deprecated? ? 'deprecated' : nil}">
       <span class="verb">#{@endpoint.verb}</span>
       <span class="root">#{zws_ify(@endpoint.service.base_path)}</span><span
-       class="path">#{zws_ify(@endpoint.path)}</span>
+       class="path">#{zws_ify(path)}</span>
       #{@endpoint.deprecated? ? '(deprecated)' : nil}
     </span>
     EOS
@@ -31,15 +31,15 @@ class Fdoc::EndpointPresenter < Fdoc::HtmlPresenter
   end
 
   def url(extension = ".html")
-    '%s%s-%s%s' % [ options[:prefix], endpoint.path, endpoint.verb, extension ]
+    '%s%s-%s%s' % [ options[:prefix], endpoint.file_path, endpoint.verb, extension ]
   end
 
   def title
-    '%s %s - %s' % [ endpoint.verb, endpoint.path, endpoint.service.name ]
+    '%s %s - %s' % [ endpoint.verb, path, endpoint.service.name ]
   end
 
   def prefix
-    endpoint.path.split("/").first
+    endpoint.file_path.split("/").first
   end
 
   def zws_ify(str)
@@ -51,12 +51,24 @@ class Fdoc::EndpointPresenter < Fdoc::HtmlPresenter
     render_markdown(endpoint.description)
   end
 
+  def show_path_params?
+    !endpoint.path_parameters.empty?
+  end
+
   def show_request?
     !endpoint.request_parameters.empty?
   end
 
   def show_response?
     !endpoint.response_parameters.empty?
+  end
+
+  def path
+    endpoint.display_path
+  end
+
+  def path_parameters
+    Fdoc::SchemaPresenter.new(endpoint.path_parameters(true), options).to_html
   end
 
   def request_parameters

--- a/lib/fdoc/presenters/html_presenter.rb
+++ b/lib/fdoc/presenters/html_presenter.rb
@@ -1,5 +1,6 @@
 require 'erb'
 require 'kramdown'
+require 'json'
 
 # HtmlPresenters assist in generating Html for fdoc classes.
 # HtmlPresenters is an abstract class with a lot of helper methods

--- a/lib/fdoc/service.rb
+++ b/lib/fdoc/service.rb
@@ -31,10 +31,11 @@ class Fdoc::Service
     end
   end
 
-  def self.verify!(verb, path, request_params, response_params,
+  def self.verify!(verb, path, request_params, response_params, path_params,
                    response_status, successful)
     service = Fdoc::Service.new(Fdoc.service_path)
     endpoint = service.open(verb, path)
+    endpoint.consume_path(path_params, successful)
     endpoint.consume_request(request_params, successful)
     endpoint.consume_response(response_params, response_status, successful)
     endpoint.persist! if endpoint.respond_to?(:persist!)

--- a/lib/fdoc/spec_watcher.rb
+++ b/lib/fdoc/spec_watcher.rb
@@ -30,7 +30,7 @@ module Fdoc
           opts.merge!(options)
           opts[:fdoc]
         end
-        
+
         real_response = nil
         if defined? response
           # we are on rails
@@ -46,8 +46,9 @@ module Fdoc
           rescue
             {}
           end
+          path_params = request.path_parameters.reject { |param| [:action, :controller].include? param }
           successful = Fdoc.decide_success(response_params, real_response.status)
-          Service.verify!(verb, path, request_params, response_params,
+          Service.verify!(verb, path, request_params, response_params, path_params,
             real_response.status, successful)
         end
 

--- a/lib/fdoc/templates/endpoint.html.erb
+++ b/lib/fdoc/templates/endpoint.html.erb
@@ -27,6 +27,13 @@
 
         <%= description %>
 
+        <% if show_path_params? %>
+          <%= tag_with_anchor('h2', 'URL') %>
+
+          <%= tag_with_anchor('h3', 'URL Parameters') %>
+          <%= path_parameters %>
+        <% end %>
+
         <% if show_request? %>
           <%= tag_with_anchor('h2', 'Request') %>
 


### PR DESCRIPTION
I've opened this issue to start a discussion on better handling for url parameters. This isn't finished code (though it works right now for our use case), but I'm happy to adjust it and improve given some feedback. This was previously mentioned in #6 but here's some more detail.

The idea is to separate request parameters from url parameters. A simple example is for resources - what you can do with the submitted change is the following:

``` ruby
describe "#show", :fdoc => "users/user" do
   get user_path(:id => 5)
end
```

``` yaml

---
# fdoc/users/user/user.fdoc.resource
description: User id
type: integer
example: 5
# optional fields...
# display_name: user_id
# name: user_key
```

When running the spec, fdoc will see that there is a resource file in that path and then know that the `user` part of the path should be dynamic. The generated html will now show two more things:
- The displayed url will be `/users/:id`
- There will be a url params section which shows the details from the user resource file.

Finally, a couple of other features:
- If resources are nested, then only the final one will be using `:id`, the others will use the containing directory name suffixed with `_id`
- The `name` field in the resource file is an override in cases when the url param is not a rails resource, and is a plain url param (eg country_code)
- The `display_name` field is how the field will appear in the html documentation. The spec will be run against `name` (or `id` if this does not exist), but usually it's more useful to refer to this as something else in the documentation.

Some things currently missing from the integration:
- Scaffolding support (you must create the resource files manually)
- Tests

Let me know what you think. I think this is a really useful feature and hope it can be integrated.
