### PR TITLE
Run specs with guard-rspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 Gemfile.lock
 .rvmrc
+.rspec
+.ruby-version
+.ruby-gemset
 html
+tmp/

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,5 @@
+guard 'rspec', :cli => '--fail-fast' do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')  { "spec" }
+end

--- a/fdoc.gemspec
+++ b/fdoc.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rspec", "~> 2.5")
   s.add_development_dependency("nokogiri")
   s.add_development_dependency("cane")
+  s.add_development_dependency("guard-rspec")
 end


### PR DESCRIPTION
- Ignore the tmp/ directory created by running guard-rspec
- Add .ruby-version and .ruby-gemset to gitignore for rbenv
