### PR TITLE
example needs to call to_html in schema_presenter

### DIFF
--- a/lib/fdoc/presenters/schema_presenter.rb
+++ b/lib/fdoc/presenters/schema_presenter.rb
@@ -40,7 +40,7 @@ class Fdoc::SchemaPresenter < Fdoc::BasePresenter
       html << '<li>Required: %s</li>' % required? if nested?
       html << '<li>Type: %s</li>' % type if type
       html << '<li>Format: %s</li>' % format if format
-      html << '<li>Example: %s</li>' % example if example
+      html << '<li>Example: %s</li>' % example.to_html if example
       html << enum_html
 
       (@schema.keys - FORMATTED_KEYS).each do |key|

--- a/spec/fdoc/presenters/schema_presenter_spec.rb
+++ b/spec/fdoc/presenters/schema_presenter_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'nokogiri'
+
+describe Fdoc::SchemaPresenter do
+  let(:schema) {
+    {
+      'description' => 'Some description text',
+      'example' => 'an example'
+    }
+  }
+  subject {
+    Fdoc::SchemaPresenter.new(schema, {})
+  }
+
+  context '#to_html' do
+    it 'should generate valid HTML' do
+      html = subject.to_html
+
+      html.should include 'Some description text'
+      html.should include 'an example'
+      expect {
+        Nokogiri::HTML(html) { |config| config.strict }
+      }.to_not raise_exception
+    end
+  end
+
+  context "#to_markdown" do
+    it "should generate markdown" do
+      markdown = subject.to_markdown
+      markdown.should include 'Some description text'
+      markdown.should include 'an example'
+    end
+  end
+end


### PR DESCRIPTION
Found a small bug. example needs a to_html as it is a JsonPresenter
