### PR TITLE
Require 'tmpdir' from spec helper

### DIFF
--- a/spec/fixtures/members/list/complex-params-GET.fdoc
+++ b/spec/fixtures/members/list/complex-params-GET.fdoc
@@ -4,84 +4,84 @@ requestParameters:
     toplevel_param:
       type: string
       description: A paramater as normal
-      required: Yes
+      required: yes
     optional_nested_array:
       type: array
-      required: No
+      required: no
       items:
         type: object
         properties:
           required_param:
-            required: Yes
+            required: yes
             description: It's required
             type: string
           optional_param:
-            required: Yes
+            required: yes
             description: It's optional
             type: string
     required_nested_array:
       type: array
-      required: Yes
+      required: yes
       items:
         type: object
         properties:
           required_param:
-            required: Yes
+            required: yes
             description: It's required
             type: string
           optional_param:
-            required: No
+            required: no
             description: It's optional
             type: string
           optional_second_nested_object:
-            required: No
+            required: no
             type: object
             description: It's a bug
             properties:
               required_param:
-                required: Yes
+                required: yes
                 description: It's required
                 type: string
               optional_param:
-                required: No
+                required: no
                 description: It's optional
                 type: string
-          
+
     optional_nested_object:
       type: object
-      required: No
+      required: no
       properties:
         required_param:
-          required: Yes
+          required: yes
           description: It's required
           type: string
         optional_param:
-          required: No
+          required: no
           description: It's optional
           type: string
     required_nested_object:
       type: object
-      required: Yes
+      required: yes
       properties:
         required_param:
-          required: Yes
+          required: yes
           description: It's required
           type: string
         optional_param:
-          required: No
+          required: no
           description: It's optional
           type: string
         optional_second_nested_object:
-          required: No
+          required: no
           type: object
           description: It's a bug
           properties:
             required_param:
-              required: Yes
+              required: yes
               description: It's required
               type: string
             optional_param:
-              required: No
+              required: no
               description: It's optional
               type: string
 


### PR DESCRIPTION
- Fixes issue when using mktmpdir

http://apidock.com/ruby/Dir/mktmpdir/class

```
Failures:

  1) Fdoc::Cli#convert when the fdoc path does not exist raises an exception
     Failure/Error: let(:temporary_path) { Dir.mktmpdir("fdoc-cli") }
     NoMethodError:
       undefined method `mktmpdir' for Dir:Class
     # ./spec/fdoc/cli_spec.rb:5:in `block (2 levels) in <top (required)>'
     # ./spec/fdoc/cli_spec.rb:6:in `block (2 levels) in <top (required)>'
     # ./spec/fdoc/cli_spec.rb:13:in `block (2 levels) in <top (required)>'
     # ./spec/support/capture_helper.rb:6:in `capture'
     # ./spec/fdoc/cli_spec.rb:15:in `block (2 levels) in <top (required)>'
```
