### PR TITLE
Require 'tmpdir' from spec helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'fdoc'
 require 'fdoc/cli'
 require 'rspec'
+require 'tmpdir'
 
 Dir.glob(File.expand_path("../support/*.rb", __FILE__)).each { |f| require f }
 


### PR DESCRIPTION
My apologies on this one. It looks like the original code including `tmpdir` from the spec helper got overwritten and was never included in PR. https://github.com/square/fdoc/pull/34.
- Fixes issue when using mktmpdir

http://apidock.com/ruby/Dir/mktmpdir/class
