### PR TITLE
Add utf8 charset to HTML templates

### DIFF
--- a/lib/fdoc/templates/endpoint.html.erb
+++ b/lib/fdoc/templates/endpoint.html.erb
@@ -4,7 +4,7 @@
     <title>
       <%= title %>
     </title>
-
+    <meta http-equiv="Content-type" content="text/html;charset=UTF-8">
     <link rel="stylesheet" type="text/css" href="<%= css_path %>" />
   </head>
   <body>

--- a/lib/fdoc/templates/meta_service.html.erb
+++ b/lib/fdoc/templates/meta_service.html.erb
@@ -4,7 +4,7 @@
     <title>
       <%= @meta_service.name %>
     </title>
-
+    <meta http-equiv="Content-type" content="text/html;charset=UTF-8">
     <link rel="stylesheet" type="text/css" href="<%= css_path %>" />
   </head>
   <body>

--- a/lib/fdoc/templates/service.html.erb
+++ b/lib/fdoc/templates/service.html.erb
@@ -4,7 +4,7 @@
     <title>
       <%= @service.name %>
     </title>
-
+    <meta http-equiv="Content-type" content="text/html;charset=UTF-8">
     <link rel="stylesheet" type="text/css" href="<%= css_path %>" />
   </head>
   <body>


### PR DESCRIPTION
I have an issue with displaying non ISO-8859-1 description text for endpoints. So I suggest using UTF-8 as a default charset for templates. I am aware that you can override templates, but it would be great if fdoc could work with any language out of the box.
