### PR TITLE
Fixes spec failures from File.join being called on a blank options[:template_directory]

### DIFF
--- a/lib/fdoc/presenters/base_presenter.rb
+++ b/lib/fdoc/presenters/base_presenter.rb
@@ -15,10 +15,7 @@ class Fdoc::BasePresenter
   end
 
   def render_erb(erb_name, binding = get_binding)
-    template_path = File.join(options[:template_directory], erb_name)
-    if !File.exists? template_path
-      template_path = File.join(File.dirname(__FILE__), "../templates", erb_name)
-    end
+    template_path = path_for_template(erb_name)
     template = ERB.new(File.read(template_path), nil, '-')
     template.result(binding)
   end
@@ -61,5 +58,16 @@ class Fdoc::BasePresenter
       </a>
     </#{tag}>
     EOS
+  end
+
+  protected
+
+  def path_for_template(filename)
+    template_dir  = options[:template_directory]
+    template_path = File.join(template_dir, filename) if template_dir
+    if template_path.nil? || !File.exists?(template_path)
+      template_path = File.join(File.dirname(__FILE__), "../templates", filename)
+    end
+    template_path
   end
 end


### PR DESCRIPTION
Current test failures:

```
.................................................................................FF.FF....FF...........

Failures:

  1) Fdoc::EndpointPresenter#to_html should generate valid HTML
     Failure/Error: html = subject.to_html
     TypeError:
       no implicit conversion of nil into String
     # ./lib/fdoc/presenters/base_presenter.rb:18:in `join'
     # ./lib/fdoc/presenters/base_presenter.rb:18:in `render_erb'
     # ./lib/fdoc/presenters/endpoint_presenter.rb:12:in `to_html'
     # ./spec/fdoc/presenters/endpoint_presenter_spec.rb:14:in `block (3 levels) in <top (required)>'

  2) Fdoc::EndpointPresenter#to_markdown should generate markdown
     Failure/Error: markdown = subject.to_markdown
     TypeError:
       no implicit conversion of nil into String
     # ./lib/fdoc/presenters/base_presenter.rb:18:in `join'
     # ./lib/fdoc/presenters/base_presenter.rb:18:in `render_erb'
     # ./lib/fdoc/presenters/endpoint_presenter.rb:16:in `to_markdown'
     # ./spec/fdoc/presenters/endpoint_presenter_spec.rb:24:in `block (3 levels) in <top (required)>'

...
```

This is caused by:

``` ruby
class Fdoc::BasePresenter
  # ...
  def render_erb(erb_name, binding = get_binding)
    template_path = File.join(options[:template_directory], erb_name)
```

... Where `options[:template_directory]` is nil (ie. the default).
