### PR TITLE
Locks json-schema to > 1.1 and < 2.0.

### DIFF
--- a/fdoc.gemspec
+++ b/fdoc.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.executables  << "fdoc"
 
   s.add_dependency("json")
-  s.add_dependency("json-schema", ">= 1.0.1")
+  s.add_dependency("json-schema", "~> 1.1")
   s.add_dependency("kramdown")
   s.add_dependency("thor")
 


### PR DESCRIPTION
Holds off (but doesn't fix) #33.
