### PR TITLE
Adds Travis-CI config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+rvm:
+  - 2.0.0
+  - 1.9.3


### PR DESCRIPTION
Lets [Travis-CI](http://travis-ci.org) know to runs tests with 1.9.3 and 2.0.0.

(This needs you to set up Travis-CI on the fdoc repository for you to reap the benefits, though.)
