### PR TITLE
Update specs to RSpec 2.14.8 syntax

### DIFF
--- a/spec/fdoc/endpoint_scaffold_spec.rb
+++ b/spec/fdoc/endpoint_scaffold_spec.rb
@@ -16,16 +16,16 @@ describe Fdoc::EndpointScaffold do
     }
 
     before(:each) do
-      subject.request_parameters.should be_empty
+      expect(subject.request_parameters).to be_empty
     end
 
     it "creates properties for top-level keys, and populates them with examples" do
       subject.consume_request(request_params, true)
-      subject.request_parameters["type"].should == nil
-      subject.request_parameters["properties"].should have(3).keys
-      subject.request_parameters["properties"]["depth"]["type"].should == "integer"
-      subject.request_parameters["properties"]["max_connections"]["example"].should == 20
-      subject.request_parameters["properties"]["root_node"]["type"].should == "string"
+      expect(subject.request_parameters["type"]).to eq(nil)
+      expect(subject.request_parameters["properties"].keys.size).to eq(3)
+      expect(subject.request_parameters["properties"]["depth"]["type"]).to eq("integer")
+      expect(subject.request_parameters["properties"]["max_connections"]["example"]).to eq(20)
+      expect(subject.request_parameters["properties"]["root_node"]["type"]).to eq("string")
     end
 
     it "infers boolean types" do
@@ -34,9 +34,9 @@ describe Fdoc::EndpointScaffold do
         "hold_the_lettuce" => true
       }
       subject.consume_request(bool_params)
-      subject.request_parameters["properties"].should have(2).keys
-      subject.request_parameters["properties"]["with_cheese"]["type"].should == "boolean"
-      subject.request_parameters["properties"]["hold_the_lettuce"]["type"].should == "boolean"
+      expect(subject.request_parameters["properties"].keys.size).to eq(2)
+      expect(subject.request_parameters["properties"]["with_cheese"]["type"]).to eq("boolean")
+      expect(subject.request_parameters["properties"]["hold_the_lettuce"]["type"]).to eq("boolean")
     end
 
     context "infers formats" do
@@ -46,11 +46,11 @@ describe Fdoc::EndpointScaffold do
           "time_obj" => Time.now
         }
         subject.consume_request(datetime_params)
-        subject.request_parameters["properties"].should have(2).keys
-        subject.request_parameters["properties"]["time_str"]["type"].should == "string"
-        subject.request_parameters["properties"]["time_str"]["format"].should == "date-time"
-        subject.request_parameters["properties"]["time_obj"]["type"].should == "string"
-        subject.request_parameters["properties"]["time_obj"]["format"].should == "date-time"
+        expect(subject.request_parameters["properties"].keys.size).to eq(2)
+        expect(subject.request_parameters["properties"]["time_str"]["type"]).to eq("string")
+        expect(subject.request_parameters["properties"]["time_str"]["format"]).to eq("date-time")
+        expect(subject.request_parameters["properties"]["time_obj"]["type"]).to eq("string")
+        expect(subject.request_parameters["properties"]["time_obj"]["format"]).to eq("date-time")
       end
 
       it "detects uri formats" do
@@ -58,16 +58,16 @@ describe Fdoc::EndpointScaffold do
           "sample_uri" => "http://my.example.com"
         }
         subject.consume_request(uri_params)
-        subject.request_parameters["properties"].should have(1).keys
-        subject.request_parameters["properties"]["sample_uri"]["type"].should == "string"
-        subject.request_parameters["properties"]["sample_uri"]["format"].should == "uri"
+        expect(subject.request_parameters["properties"].keys.size).to eq(1)
+        expect(subject.request_parameters["properties"]["sample_uri"]["type"]).to eq("string")
+        expect(subject.request_parameters["properties"]["sample_uri"]["format"]).to eq("uri")
       end
 
       it "detects color formats (hex only for now)" do
         color_params = { "page_color" => "#AABBCC" }
         subject.consume_request(color_params)
-        subject.request_parameters["properties"]["page_color"]["type"].should == "string"
-        subject.request_parameters["properties"]["page_color"]["format"].should == "color"
+        expect(subject.request_parameters["properties"]["page_color"]["type"]).to eq("string")
+        expect(subject.request_parameters["properties"]["page_color"]["format"]).to eq("color")
       end
     end
 
@@ -77,11 +77,11 @@ describe Fdoc::EndpointScaffold do
         "with_string" => true
       }
       subject.consume_request(mixed_params)
-      subject.request_parameters["properties"].should have(2).keys
-      subject.request_parameters["properties"].should have_key "with_symbol"
-      subject.request_parameters["properties"].should_not have_key :with_symbol
-      subject.request_parameters["properties"].should have_key "with_string"
-      subject.request_parameters["properties"].should_not have_key :with_string
+      expect(subject.request_parameters["properties"].keys.size).to eq(2)
+      expect(subject.request_parameters["properties"]).to have_key "with_symbol"
+      expect(subject.request_parameters["properties"]).not_to have_key :with_symbol
+      expect(subject.request_parameters["properties"]).to have_key "with_string"
+      expect(subject.request_parameters["properties"]).not_to have_key :with_string
     end
 
     it "uses strings (not symbols) for keys of nested hashes" do
@@ -93,7 +93,7 @@ describe Fdoc::EndpointScaffold do
       }
 
       subject.consume_request(mixed_params)
-      subject.request_parameters["properties"]["nested_object"]["properties"].keys.sort.should == ["with_string", "with_symbol"]
+      expect(subject.request_parameters["properties"]["nested_object"]["properties"].keys.sort).to eq(["with_string", "with_symbol"])
     end
 
     it "uses strings (not symbols) for nested hashes inside arrays" do
@@ -107,13 +107,13 @@ describe Fdoc::EndpointScaffold do
       }
 
       subject.consume_request(mixed_params)
-      subject.request_parameters["properties"]["nested_array"]["items"]["properties"].keys.sort.should == ["with_string", "with_symbol"]
+      expect(subject.request_parameters["properties"]["nested_array"]["items"]["properties"].keys.sort).to eq(["with_string", "with_symbol"])
     end
 
     it "produces a valid JSON schema for the response" do
       subject.consume_request(request_params)
-      subject.request_parameters["properties"].should have(3).keys
-      JSON::Validator.validate!(subject.request_parameters, request_params).should be_true
+      expect(subject.request_parameters["properties"].keys.size).to eq(3)
+      expect(JSON::Validator.validate!(subject.request_parameters, request_params)).to be_true
     end
   end
 
@@ -151,57 +151,57 @@ describe Fdoc::EndpointScaffold do
 
     context "for succesful responses" do
       before(:each) do
-        subject.should have(0).response_codes
+        expect(subject.response_codes.size).to eq(0)
       end
 
       it "adds response codes" do
         subject.consume_response({}, "200 OK")
-        subject.should have(1).response_codes
+        expect(subject.response_codes.size).to eq(1)
 
         subject.consume_response({}, "201 Created")
-        subject.should have(2).response_codes
+        expect(subject.response_codes.size).to eq(2)
       end
 
      it "does not add duplicate response codes" do
         subject.consume_response({}, "200 OK")
-        subject.should have(1).response_codes
+        expect(subject.response_codes.size).to eq(1)
 
         subject.consume_response({}, "200 OK")
-        subject.should have(1).response_codes
+        expect(subject.response_codes.size).to eq(1)
 
         subject.response_codes.each do |response|
-          response["description"].should == "???"
+          expect(response["description"]).to eq("???")
         end
       end
 
       it "creates properties for top-level keys, and populates them with examples" do
         subject.consume_response(response_params, "200 OK")
-        subject.response_parameters["type"].should == nil
-        subject.response_parameters["properties"].keys.should =~ ["nodes", "root_node", "std_dev", "version", "updated_at"]
+        expect(subject.response_parameters["type"]).to eq(nil)
+        expect(subject.response_parameters["properties"].keys).to match_array(["nodes", "root_node", "std_dev", "version", "updated_at"])
 
-        subject.response_parameters["properties"]["nodes"]["type"].should == "array"
-        subject.response_parameters["properties"]["nodes"]["description"].should == "???"
-        subject.response_parameters["properties"]["nodes"]["required"].should == "???"
+        expect(subject.response_parameters["properties"]["nodes"]["type"]).to eq("array")
+        expect(subject.response_parameters["properties"]["nodes"]["description"]).to eq("???")
+        expect(subject.response_parameters["properties"]["nodes"]["required"]).to eq("???")
 
-        subject.response_parameters["properties"]["root_node"]["type"].should == "object"
-        subject.response_parameters["properties"]["root_node"]["description"].should == "???"
-        subject.response_parameters["properties"]["root_node"]["required"].should == "???"
+        expect(subject.response_parameters["properties"]["root_node"]["type"]).to eq("object")
+        expect(subject.response_parameters["properties"]["root_node"]["description"]).to eq("???")
+        expect(subject.response_parameters["properties"]["root_node"]["required"]).to eq("???")
 
-        subject.response_parameters["properties"]["version"]["type"].should == "integer"
-        subject.response_parameters["properties"]["std_dev"]["type"].should == "number"
+        expect(subject.response_parameters["properties"]["version"]["type"]).to eq("integer")
+        expect(subject.response_parameters["properties"]["std_dev"]["type"]).to eq("number")
       end
 
       it "populates items in arrays" do
         subject.consume_response(response_params, "200 OK")
-        subject.response_parameters["properties"]["nodes"]["type"].should == "array"
-        subject.response_parameters["properties"]["nodes"]["items"]["type"].should == "object"
-        subject.response_parameters["properties"]["nodes"]["items"]["properties"].keys.sort.should == [
-          "id", "linked_to","name"]
+        expect(subject.response_parameters["properties"]["nodes"]["type"]).to eq("array")
+        expect(subject.response_parameters["properties"]["nodes"]["items"]["type"]).to eq("object")
+        expect(subject.response_parameters["properties"]["nodes"]["items"]["properties"].keys.sort).to eq([
+          "id", "linked_to","name"])
       end
 
       it "turns nil into null" do
         subject.consume_response(response_params, "200 OK")
-        subject.response_parameters["properties"]["updated_at"]["type"].should == "null"
+        expect(subject.response_parameters["properties"]["updated_at"]["type"]).to eq("null")
       end
 
       it "uses strings (not symbols) as keys" do
@@ -210,32 +210,32 @@ describe Fdoc::EndpointScaffold do
           "with_string" => true
         }
         subject.consume_response(mixed_params, "200 OK")
-        subject.response_parameters["properties"].should have(2).keys
-        subject.response_parameters["properties"].should have_key "with_symbol"
-        subject.response_parameters["properties"].should_not have_key :with_symbol
-        subject.response_parameters["properties"].should have_key "with_string"
-        subject.response_parameters["properties"].should_not have_key :with_string
+        expect(subject.response_parameters["properties"].keys.size).to eq(2)
+        expect(subject.response_parameters["properties"]).to have_key "with_symbol"
+        expect(subject.response_parameters["properties"]).not_to have_key :with_symbol
+        expect(subject.response_parameters["properties"]).to have_key "with_string"
+        expect(subject.response_parameters["properties"]).not_to have_key :with_string
       end
 
       it "produces a valid JSON schema for the response" do
         subject.consume_response(response_params, "200 OK")
-        JSON::Validator.validate!(subject.response_parameters, response_params).should be_true
+        expect(JSON::Validator.validate!(subject.response_parameters, response_params)).to be_true
       end
     end
 
     context "for unsuccessful responses" do
       it "adds response codes" do
-        subject.should have(0).response_codes
+        expect(subject.response_codes.size).to eq(0)
         subject.consume_response({}, "400 Bad Request", false)
-        subject.should have(1).response_codes
+        expect(subject.response_codes.size).to eq(1)
         subject.consume_response({}, "404 Not Found", false)
-        subject.should have(2).response_codes
+        expect(subject.response_codes.size).to eq(2)
       end
 
       it "does not modify the response_parameters" do
-        subject.response_parameters.should be_empty
+        expect(subject.response_parameters).to be_empty
         subject.consume_response(response_params, "403 Forbidden", false)
-        subject.response_parameters.should be_empty
+        expect(subject.response_parameters).to be_empty
       end
     end
   end

--- a/spec/fdoc/endpoint_spec.rb
+++ b/spec/fdoc/endpoint_spec.rb
@@ -23,13 +23,13 @@ describe Fdoc::Endpoint do
 
   describe "#verb" do
     it "infers the verb from the filename and service" do
-      subject.verb.should == "GET"
+      expect(subject.verb).to eq("GET")
     end
   end
 
   describe "#path" do
     it "infers its path from the filename and service" do
-      subject.path.should == "members/list"
+      expect(subject.path).to eq("members/list")
     end
   end
 
@@ -45,7 +45,7 @@ describe Fdoc::Endpoint do
 
     context "with a well-behaved request" do
       it "returns true" do
-        subject.should be_true
+        expect(subject).to be_true
       end
     end
 
@@ -110,18 +110,18 @@ describe Fdoc::Endpoint do
       }
 
       it "is successful" do
-        subject.should be_true
+        expect(subject).to be_true
       end
 
       context "with no optional keys" do
         before { remove_optional(params) }
 
         it "does not contain optional keys" do
-          params.keys.sort.should == ["required_nested_array", "required_nested_object", "toplevel_param"]
+          expect(params.keys.sort).to eq(["required_nested_array", "required_nested_object", "toplevel_param"])
         end
 
         it "is successful" do
-          subject.should be_true
+          expect(subject).to be_true
         end
       end
 
@@ -214,11 +214,11 @@ describe Fdoc::Endpoint do
 
     context "for successful responses" do
       it "validates the response parameters against the schema" do
-        subject.consume_response(good_response_params, "200 OK").should be_true
+        expect(subject.consume_response(good_response_params, "200 OK")).to be_true
       end
 
       it "allows either fully-qualified or integer HTTP status codes" do
-        subject.consume_response(good_response_params, 200).should be_true
+        expect(subject.consume_response(good_response_params, 200)).to be_true
       end
 
       context "with unknown keys" do
@@ -239,7 +239,7 @@ describe Fdoc::Endpoint do
       context "when there is a valid success-code response" do
         it "does not throw an error with bad response parameters" do
           bad_params = good_response_params.merge({"extra_goodness" => true})
-          subject.consume_response(bad_params, "400 Bad Request", false).should be_true
+          expect(subject.consume_response(bad_params, "400 Bad Request", false)).to be_true
         end
       end
     end

--- a/spec/fdoc/presenters/base_presenter_spec.rb
+++ b/spec/fdoc/presenters/base_presenter_spec.rb
@@ -14,14 +14,14 @@ describe Fdoc::BasePresenter do
 
   context "#render_erb" do
     it "renders a default template" do
-      File.should_receive(:exists?).with('templates/test.html.erb').and_return(false)
-      File.stub(:read).and_return('test content')
+      expect(File).to receive(:exists?).with('templates/test.html.erb').and_return(false)
+      allow(File).to receive(:read).and_return('test content')
       subject.to_html
     end
 
     it "renders from local template directory" do
-      File.should_receive(:exists?).with('templates/test.html.erb').and_return(true)
-      File.should_receive(:read).with('templates/test.html.erb').and_return('test content')
+      expect(File).to receive(:exists?).with('templates/test.html.erb').and_return(true)
+      expect(File).to receive(:read).with('templates/test.html.erb').and_return('test content')
       subject.to_html
     end
   end

--- a/spec/fdoc/presenters/endpoint_presenter_spec.rb
+++ b/spec/fdoc/presenters/endpoint_presenter_spec.rb
@@ -22,7 +22,7 @@ describe Fdoc::EndpointPresenter do
   context "#to_markdown" do
     it "should generate markdown" do
       markdown = subject.to_markdown
-      markdown.should include "# GET spec&#8203;/fixtures&#8203;/members&#8203;/list"
+      expect(markdown).to include "# GET spec&#8203;/fixtures&#8203;/members&#8203;/list"
     end
   end
 
@@ -94,7 +94,7 @@ describe Fdoc::EndpointPresenter do
     }
 
     it "should generate an example response from the contents of the schema" do
-      subject.example_from_schema(example_schema).should == expected_example
+      expect(subject.example_from_schema(example_schema)).to eq(expected_example)
     end
   end
 end

--- a/spec/fdoc/presenters/meta_service_presenter_spec.rb
+++ b/spec/fdoc/presenters/meta_service_presenter_spec.rb
@@ -19,8 +19,8 @@ describe Fdoc::MetaServicePresenter do
   context "#to_markdown" do
     it "should generate markdown" do
       markdown = subject.to_markdown
-      markdown.should include "* PUT [https:&#8203;/&#8203;/api.sample.com&#8203;/members&#8203;/add](members_api/add-PUT.md)"
-      markdown.should include "* POST [https:&#8203;/&#8203;/api.sample.com&#8203;/members&#8203;/draft](members_api/draft-POST.md)"
+      expect(markdown).to include "* PUT [https:&#8203;/&#8203;/api.sample.com&#8203;/members&#8203;/add](members_api/add-PUT.md)"
+      expect(markdown).to include "* POST [https:&#8203;/&#8203;/api.sample.com&#8203;/members&#8203;/draft](members_api/draft-POST.md)"
     end
   end
 
@@ -28,11 +28,11 @@ describe Fdoc::MetaServicePresenter do
     let(:service) { subject.services.first }
 
     it "returns relative path" do
-      subject.relative_service_path(service).should == "members_api"
+      expect(subject.relative_service_path(service)).to eq("members_api")
     end
 
     it "should join relative path if passed in a filename" do
-      subject.relative_service_path(service, 'index.md').should == "members_api/index.md"
+      expect(subject.relative_service_path(service, 'index.md')).to eq("members_api/index.md")
     end
   end
 end

--- a/spec/fdoc/presenters/schema_presenter_spec.rb
+++ b/spec/fdoc/presenters/schema_presenter_spec.rb
@@ -16,8 +16,8 @@ describe Fdoc::SchemaPresenter do
     it 'should generate valid HTML' do
       html = subject.to_html
 
-      html.should include 'Some description text'
-      html.should include 'an example'
+      expect(html).to include 'Some description text'
+      expect(html).to include 'an example'
       expect {
         Nokogiri::HTML(html) { |config| config.strict }
       }.to_not raise_exception
@@ -27,8 +27,8 @@ describe Fdoc::SchemaPresenter do
   context "#to_markdown" do
     it "should generate markdown" do
       markdown = subject.to_markdown
-      markdown.should include 'Some description text'
-      markdown.should include 'an example'
+      expect(markdown).to include 'Some description text'
+      expect(markdown).to include 'an example'
     end
   end
 end

--- a/spec/fdoc/presenters/service_presenter_spec.rb
+++ b/spec/fdoc/presenters/service_presenter_spec.rb
@@ -19,8 +19,8 @@ describe Fdoc::ServicePresenter do
   context "#to_markdown" do
     it "should generate markdown" do
       markdown = subject.to_markdown
-      markdown.should include "* PUT [https:&#8203;/&#8203;/api.sample.com&#8203;/members&#8203;/add](add-PUT.md)"
-      markdown.should include "* POST [https:&#8203;/&#8203;/api.sample.com&#8203;/members&#8203;/draft](draft-POST.md)"
+      expect(markdown).to include "* PUT [https:&#8203;/&#8203;/api.sample.com&#8203;/members&#8203;/add](add-PUT.md)"
+      expect(markdown).to include "* POST [https:&#8203;/&#8203;/api.sample.com&#8203;/members&#8203;/draft](draft-POST.md)"
     end
   end
 
@@ -34,7 +34,7 @@ describe Fdoc::ServicePresenter do
 
     context "pass in filename" do
       it "should join with filename" do
-        subject.relative_meta_service_path('index.md').should == "../index.md"
+        expect(subject.relative_meta_service_path('index.md')).to eq "../index.md"
       end
     end
   end

--- a/spec/fdoc/service_spec.rb
+++ b/spec/fdoc/service_spec.rb
@@ -11,8 +11,8 @@ describe Fdoc::Service do
     context "in regular mode" do
       it "returns an Endpoint object" do
         endpoint = subject.open(verb, path, scaffold_mode)
-        endpoint.should     be_kind_of(Fdoc::Endpoint)
-        endpoint.should_not be_kind_of(Fdoc::EndpointScaffold)
+        expect(endpoint).to     be_kind_of(Fdoc::Endpoint)
+        expect(endpoint).not_to be_kind_of(Fdoc::EndpointScaffold)
       end
     end
 
@@ -20,7 +20,7 @@ describe Fdoc::Service do
       let(:scaffold_mode) { true }
 
       it "returns an EndpointScaffold object" do
-        subject.open(verb, path, scaffold_mode).should be_kind_of(Fdoc::EndpointScaffold)
+        expect(subject.open(verb, path, scaffold_mode)).to be_kind_of(Fdoc::EndpointScaffold)
       end
     end
   end
@@ -31,32 +31,32 @@ describe Fdoc::Service do
 
     context "when a flat named filename exists" do
       before do
-        File.should_receive(:exist?).with(flat_file_name).and_return(true)
+        expect(File).to receive(:exist?).with(flat_file_name).and_return(true)
       end
 
       it "returns the flat named file path" do
-        subject.path_for(verb, path).should == flat_file_name
+        expect(subject.path_for(verb, path)).to eq(flat_file_name)
       end
     end
 
     context "when a no flat named named file exists, but a nested path does" do
       before do
-        File.should_receive(:exist?).with(flat_file_name).and_return(false)
-        File.should_receive(:exist?).with(nested_file_name).and_return(true)
+        expect(File).to receive(:exist?).with(flat_file_name).and_return(false)
+        expect(File).to receive(:exist?).with(nested_file_name).and_return(true)
       end
 
       it "returns the nested named file path" do
-        subject.path_for(verb, path).should == nested_file_name
+        expect(subject.path_for(verb, path)).to eq(nested_file_name)
       end
     end
 
     context "when no file exists" do
       before do
-        File.stub(:exist?).and_return(false)
+        allow(File).to receive(:exist?).and_return(false)
       end
 
       it "returns the flat named file path" do
-        subject.path_for(verb, path).should == flat_file_name
+        expect(subject.path_for(verb, path)).to eq(flat_file_name)
       end
     end
   end

--- a/spec/fdoc/spec_watcher_spec.rb
+++ b/spec/fdoc/spec_watcher_spec.rb
@@ -25,16 +25,16 @@ describe Fdoc::SpecWatcher do
     end
 
     it 'should verify when params are a hash' do
-      Fdoc::Service.should_receive(:verify!).with do |*args|
+      expect(Fdoc::Service).to receive(:verify!).with { |*args|
         args[2] == {:id => 1}
-      end
+      }
       @klass.get(:index, {:id => 1})
     end
 
     it 'should verify when params are JSON' do
-      Fdoc::Service.should_receive(:verify!).with do |*args|
+      expect(Fdoc::Service).to receive(:verify!).with { |*args|
         args[2] == {'id' => 1}
-      end
+      }
       @klass.get(:index, {:id => 1}.to_json)
     end
   end
@@ -61,16 +61,16 @@ describe Fdoc::SpecWatcher do
     end
 
     it 'should verify when params are a hash' do
-      Fdoc::Service.should_receive(:verify!).with do |*args|
+      expect(Fdoc::Service).to receive(:verify!).with { |*args|
         args[2] == {:id => 1}
-      end
+      }
       @klass.get("/", {:id => 1})
     end
 
     it 'should verify when params are JSON' do
-      Fdoc::Service.should_receive(:verify!).with do |*args|
+      expect(Fdoc::Service).to receive(:verify!).with { |*args|
         args[2] == {'id' => 1}
-      end
+      }
       @klass.get("/", {:id => 1}.to_json)
     end
   end
@@ -80,7 +80,7 @@ describe Fdoc::SpecWatcher do
       include Fdoc::SpecWatcher
     end.new
     [:get, :post, :put, :patch, :delete].each do |verb|
-      klass.method(verb).owner.should be Fdoc::SpecWatcher
+      expect(klass.method(verb).owner).to be Fdoc::SpecWatcher
     end
   end
 end


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec spec/fdoc/presenters spec/fdoc/endpoint_scaffold_spec.rb spec/fdoc/endpoint_spec.rb spec/fdoc/service_spec.rb spec/fdoc/spec_watcher_spec.rb
- 83 conversions
  from: obj.should
    to: expect(obj).to
- 40 conversions
  from: == expected
    to: eq(expected)
- 10 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 8 conversions
  from: obj.should have(n).response_codes
    to: expect(obj.response_codes.size).to eq(n)
- 7 conversions
  from: obj.should have(n).keys
    to: expect(obj.keys.size).to eq(n)
- 5 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 2 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
- 1 conversion
  from: =~ [1, 2]
    to: match_array([1, 2])
- 1 conversion
  from: its(:attr) { }
    to: describe '#attr' do subject { super().attr }; it { } end
