### PR TITLE
Make scaffold example valid RSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ end
 To enable fdoc for an endpoint, add the `fdoc` option with the path to the endpoint. fdoc will intercept all calls to `get`, `post`, `put`, and `delete` and verify those parameters accordingly.
 
 ```ruby
-context "#show", :fdoc => 'members/list' do
+context "#show", fdoc: 'members/list' do
   # ...
 end
 ```
@@ -152,7 +152,7 @@ Our spec file, `spec/controllers/members_controller_spec.rb` looks like:
 require 'fdoc/spec_watcher'
 
 describe MembersController do
-  context "#show", :fdoc => "members/list" do
+  context "#show", fdoc: "members/list" do
     it "can take an offset" do
       get :show, {
         :offset => 5

--- a/docs/scaffold.md
+++ b/docs/scaffold.md
@@ -8,11 +8,13 @@ require 'fdoc/spec_watcher'
 describe MembersController do
   include Fdoc::SpecWatcher
 
-  context "#list", :fdoc => 'members/list' do
-    get :list, {
-      :limit => 10,
-      :older_than => Time.gm(2012,"jun",21,10,40,00)
-    }
+  context "#list", fdoc: 'members/list' do
+    it "lists members scoped to age" do
+      get :list, {
+        limit: 10,
+        older_than: Time.gm(2012,"jun",21,10,40,00)
+      }
+    end
   end
 end
 ````


### PR DESCRIPTION
* Valid RSpec controller specs must have an `it` block
* Also convert to new hash syntax