### PR TITLE
Add Support for JSONAPI Spec `type` field

### DIFF
--- a/lib/fdoc/endpoint_scaffold.rb
+++ b/lib/fdoc/endpoint_scaffold.rb
@@ -72,7 +72,7 @@ class Fdoc::EndpointScaffold < Fdoc::Endpoint
     schema["properties"] ||= {}
 
     params.each do |key, value|
-      unless schema[key]
+      unless schema[key] && available_types.include?(value)
         schema["properties"][key] ||= {}
         sub_options = options.merge(:root_object => false)
         scaffold_schema(schema["properties"][key], value, sub_options)
@@ -110,6 +110,11 @@ class Fdoc::EndpointScaffold < Fdoc::Endpoint
       "NilClass" => "null"
     }
     type_map[in_type] || in_type.downcase
+  end
+
+  def available_types
+    # Found at: http://json-schema.org/latest/json-schema-core.html#anchor8
+    %w( array boolean integer number null object string )
   end
 
   def guess_format(value)


### PR DESCRIPTION
We're using [JSON API](http://jsonapi.org) for a project.
My Specs were failing due to the JSON Schema saying that `type` wasn't in the scaffolded response.

Ultimately, the loop was skipping the adding of an attribute if the key was `type`, which - in the JSONAPI Spec, `type` is used to denote the type of object in the response. Ex:

``` javascript
{
  "data": {
    "type": "articles",
    "id": "1",
    "attributes": {
      // ... this article's attributes
    },
    "relationships": {
      // ... this article's relationships
    }
  }
}
```
